### PR TITLE
Correção do manipulação de dias uteis para add e subtract

### DIFF
--- a/src/main/java/com/contaazul/dsl/DateBuilder.java
+++ b/src/main/java/com/contaazul/dsl/DateBuilder.java
@@ -48,18 +48,18 @@ public final class DateBuilder {
 	}
 
 	private void moveWorkingDays(TimeUnit timeUnit) {
-		int moves = timeUnit.size;
-		int moved = 0;
-		int nextMove = (moves > 0) ? 1 : -1;
-		while (moved != moves)
-			moved = moveWorkingDay( timeUnit, moved, nextMove );
+		int size = timeUnit.size;
+		int sizeMoved = 0;
+		int nextMove = (size > 0) ? 1 : -1;
+		while (sizeMoved != size)
+			sizeMoved = moveWorkingDay( timeUnit, sizeMoved, nextMove );
 	}
 
-	private int moveWorkingDay(TimeUnit unit, int moved, int move) {
+	private int moveWorkingDay(TimeUnit unit, int sizeMoved, int move) {
 		date.add( unit.type, move );
 		if (!isWeekend())
-			moved += move;
-		return moved;
+			sizeMoved += move;
+		return sizeMoved;
 	}
 
 	/**

--- a/src/main/java/com/contaazul/dsl/DateBuilder.java
+++ b/src/main/java/com/contaazul/dsl/DateBuilder.java
@@ -35,28 +35,31 @@ public final class DateBuilder {
 	/**
 	 * Ajout de TimeUnit a une date.
 	 * 
-	 * @param unit
+	 * @param timeUnit
 	 *            TimeUnit
 	 * @return DateBuilder
 	 */
-	public DateBuilder add(TimeUnit unit) {
-
-		if (unit.workingDay) {
-			int nbDay = unit.size;
-			int i = 0;
-			while (i != nbDay) {
-
-				date.add( unit.type, 1 );
-
-				if (!isWeekend()) {
-					i++;
-				}
-			}
-
-		} else {
-			date.add( unit.type, unit.size );
-		}
+	public DateBuilder add(TimeUnit timeUnit) {
+		if (timeUnit.workingDay)
+			moveWorkingDays( timeUnit );
+		else
+			date.add( timeUnit.type, timeUnit.size );
 		return this;
+	}
+
+	private void moveWorkingDays(TimeUnit timeUnit) {
+		int moves = timeUnit.size;
+		int moved = 0;
+		int nextMove = (moves > 0) ? 1 : -1;
+		while (moved != moves)
+			moved = moveWorkingDay( timeUnit, moved, nextMove );
+	}
+
+	private int moveWorkingDay(TimeUnit unit, int moved, int move) {
+		date.add( unit.type, move );
+		if (!isWeekend())
+			moved += move;
+		return moved;
 	}
 
 	/**
@@ -293,8 +296,7 @@ public final class DateBuilder {
 	 * @return DateBuilder
 	 */
 	public DateBuilder subtract(TimeUnit unit) {
-		date.add( unit.type, -unit.size );
-		return this;
+		return add( new TimeUnit( unit.type, -unit.size, unit.workingDay ) );
 	}
 
 	public Calendar toCalendar() {

--- a/src/main/java/com/contaazul/dsl/TimeUnit.java
+++ b/src/main/java/com/contaazul/dsl/TimeUnit.java
@@ -16,7 +16,7 @@ public class TimeUnit {
 	public TimeUnit(int type, int size, boolean workingDay) {
 		this.type = type;
 		this.size = size;
-		this.workingDay = true;
+		this.workingDay = workingDay;
 	}
 
 	public int getType() {

--- a/src/test/java/com/contaazul/dsl/DateDslTest.java
+++ b/src/test/java/com/contaazul/dsl/DateDslTest.java
@@ -15,6 +15,8 @@ import static com.contaazul.dsl.DateDsl.tomorrow;
 import static com.contaazul.dsl.DateDsl.workingDays;
 import static com.contaazul.dsl.DateDsl.years;
 import static com.contaazul.dsl.DateDsl.yesterday;
+import static java.util.Calendar.FEBRUARY;
+import static java.util.Calendar.MARCH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -396,11 +398,23 @@ public class DateDslTest {
 				range().startWith( yesterday().clearTime() )
 						.endWith( tomorrow().clearTime() )
 						.getElapsedDays() );
+	}
 
+	@Test
+	public void testGetElapsedDaysWithTwoLeapYear() {
 		assertEquals(
-				1830,
-				range().startWith( yesterday().clearTime() )
-						.endWith( now().add( years( 5 ) ).add( hours( 50 ) ) )
+				1829,
+				range().startWith( date( 2015, FEBRUARY, 28 ).clearTime() )
+						.endWith( date( 2020, MARCH, 1, 12, 0, 0, 0 ) )
+						.getElapsedDays() );
+	}
+
+	@Test
+	public void testGetElapsedDaysWithOneLeapYear() {
+		assertEquals(
+				1828,
+				range().startWith( date( 2015, FEBRUARY, 27 ).clearTime() )
+						.endWith( date( 2020, FEBRUARY, 28, 16, 0, 0, 0 ) )
 						.getElapsedDays() );
 	}
 
@@ -622,7 +636,7 @@ public class DateDslTest {
 	}
 
 	@Test
-	public void testWorkingDays() {
+	public void testAddWorkingDays() {
 		DateBuilder dt = emptyDate();
 		assertEquals( 1, dt.getDayOfMonth() );
 		assertEquals( Calendar.THURSDAY, dt.getDayOfWeek() );
@@ -631,11 +645,19 @@ public class DateDslTest {
 		assertEquals( 12, dt.getDayOfMonth() );
 		assertEquals( Calendar.THURSDAY, dt.getDayOfWeek() );
 		assertEquals( Calendar.FEBRUARY, dt.getMonth() );
+	}
 
-		dt.subtract( days( 3 ) );
-		assertEquals( 9, dt.getDayOfMonth() );
-		assertEquals( Calendar.MONDAY, dt.getDayOfWeek() );
-		assertEquals( Calendar.FEBRUARY, dt.getMonth() );
+	@Test
+	public void testSubtractWorkingDays() {
+		DateBuilder dt = emptyDate();
+		assertEquals( 1, dt.getDayOfMonth() );
+		assertEquals( Calendar.JANUARY, dt.getMonth() );
+		assertEquals( Calendar.THURSDAY, dt.getDayOfWeek() );
+
+		dt.subtract( workingDays( 9 ) );
+		assertEquals( 19, dt.getDayOfMonth() );
+		assertEquals( Calendar.FRIDAY, dt.getDayOfWeek() );
+		assertEquals( Calendar.DECEMBER, dt.getMonth() );
 	}
 
 	@Test

--- a/src/test/java/com/contaazul/dsl/DateDslTest.java
+++ b/src/test/java/com/contaazul/dsl/DateDslTest.java
@@ -15,8 +15,11 @@ import static com.contaazul.dsl.DateDsl.tomorrow;
 import static com.contaazul.dsl.DateDsl.workingDays;
 import static com.contaazul.dsl.DateDsl.years;
 import static com.contaazul.dsl.DateDsl.yesterday;
+import static java.util.Calendar.DECEMBER;
 import static java.util.Calendar.FEBRUARY;
+import static java.util.Calendar.FRIDAY;
 import static java.util.Calendar.MARCH;
+import static java.util.Calendar.THURSDAY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -638,26 +641,19 @@ public class DateDslTest {
 	@Test
 	public void testAddWorkingDays() {
 		DateBuilder dt = emptyDate();
-		assertEquals( 1, dt.getDayOfMonth() );
-		assertEquals( Calendar.THURSDAY, dt.getDayOfWeek() );
-
 		dt.add( workingDays( 30 ) );
 		assertEquals( 12, dt.getDayOfMonth() );
-		assertEquals( Calendar.THURSDAY, dt.getDayOfWeek() );
-		assertEquals( Calendar.FEBRUARY, dt.getMonth() );
+		assertEquals( THURSDAY, dt.getDayOfWeek() );
+		assertEquals( FEBRUARY, dt.getMonth() );
 	}
 
 	@Test
 	public void testSubtractWorkingDays() {
 		DateBuilder dt = emptyDate();
-		assertEquals( 1, dt.getDayOfMonth() );
-		assertEquals( Calendar.JANUARY, dt.getMonth() );
-		assertEquals( Calendar.THURSDAY, dt.getDayOfWeek() );
-
 		dt.subtract( workingDays( 9 ) );
 		assertEquals( 19, dt.getDayOfMonth() );
-		assertEquals( Calendar.FRIDAY, dt.getDayOfWeek() );
-		assertEquals( Calendar.DECEMBER, dt.getMonth() );
+		assertEquals( FRIDAY, dt.getDayOfWeek() );
+		assertEquals( DECEMBER, dt.getMonth() );
 	}
 
 	@Test

--- a/src/test/java/com/contaazul/dsl/DateDslTest.java
+++ b/src/test/java/com/contaazul/dsl/DateDslTest.java
@@ -405,20 +405,18 @@ public class DateDslTest {
 
 	@Test
 	public void testGetElapsedDaysWithTwoLeapYear() {
-		assertEquals(
-				1829,
-				range().startWith( date( 2015, FEBRUARY, 28 ).clearTime() )
-						.endWith( date( 2020, MARCH, 1, 12, 0, 0, 0 ) )
-						.getElapsedDays() );
+		DateBuilder start = date( 2015, FEBRUARY, 28 ).clearTime();
+		DateBuilder end = date( 2020, MARCH, 1, 12, 0, 0, 0 );
+		int elapsedDays = range().startWith( start ).endWith( end ).getElapsedDays();
+		assertEquals( 1829, elapsedDays );
 	}
 
 	@Test
 	public void testGetElapsedDaysWithOneLeapYear() {
-		assertEquals(
-				1828,
-				range().startWith( date( 2015, FEBRUARY, 27 ).clearTime() )
-						.endWith( date( 2020, FEBRUARY, 28, 16, 0, 0, 0 ) )
-						.getElapsedDays() );
+		DateBuilder start = date( 2015, FEBRUARY, 27 ).clearTime();
+		DateBuilder end = date( 2020, FEBRUARY, 28, 16, 0, 0, 0 );
+		int elapsedDays = range().startWith( start ).endWith( end ).getElapsedDays();
+		assertEquals( 1828, elapsedDays );
 	}
 
 	@Test


### PR DESCRIPTION
O método subtract não considerava dias uteis e o método add() com número negativo para dia útil entrava em loop infinito.

Além disso havia um teste unitário que calculava a quantidade de dias entre duas data, que passou a quebrar a partir do dia 28/02/2015 porque a faixa de datas consideradas no teste (que era dinamica) passou a incluir dois anos bisextos.
Alterei para fazer dois testes separados com datas fixas, sendo um deles forçando a situação de dois anos bisextos no período.